### PR TITLE
The option [:binary] is wrong, and causes an error with Socket ~> 0.3.6

### DIFF
--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -21,7 +21,7 @@ defmodule DNS do
       qdlist: [%DNS.Query{domain: to_char_list(domain), type: :a, class: :in}]
     }
 
-    client = Socket.UDP.open!(0, [:binary])
+    client = Socket.UDP.open!(0)
 
     send!(client, DNS.Record.encode(record), dns_server)
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule DNS.Mixfile do
      elixir: "~> 1.2 or ~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "socket": {:hex, :socket, "0.3.5", "6c23772e7eda60f129f36dd69a61930aab18ae9b8d74d7f767c85355cf0b585d", [:mix], []}}
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "socket": {:hex, :socket, "0.3.6", "12e115260ee48646751a16a3e98a4b1594c94d346894a8087b94bf5c7e59e6b2", [:mix], []}}


### PR DESCRIPTION
Before version 0.3.6 the parsing of the supplied option was much more lenient.
Therefore the erroneous option [:binary] was ignored.
With version 0.3.6 the parsing was completely rewritten, and now errors out.
The option should be `as: :binary`, but since this is the default, better just to leave it off.
