### PR TITLE
Change resolve to handle not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ The package is available in [Hex](https://hex.pm) and can be installed as:
 
 ```elixir
 iex> DNS.resolve("google.com")
-{216, 58, 221, 110}
+{:ok, [{216, 58, 221, 110}]}
+
+iex> DNS.resolve("notfound.domain")
+{:error, :not_found}
 
 iex> DNS.query("google.com")
 %DNS.Record{anlist: [%DNS.Resource{bm: [], class: :in, cnt: 0,

--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -5,7 +5,7 @@ defmodule DNS do
   TODO: docs
   TODO: handle errors
   """
-  @spec resolve(char_list | char_list, { String.t, :inet.port }) :: :inet.ip
+  @spec resolve(char_list | char_list, { String.t, :inet.port }) :: {atom, :inet.ip} | {atom, atom}
   def resolve(domain, dns_server \\ { "8.8.8.8", 53 }) do
     case query(domain, dns_server).anlist do
       answers when is_list(answers) and length(answers) > 0 ->

--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -7,8 +7,17 @@ defmodule DNS do
   """
   @spec resolve(char_list | char_list, { String.t, :inet.port }) :: :inet.ip
   def resolve(domain, dns_server \\ { "8.8.8.8", 53 }) do
-    [ answer | _ ] = query(domain, dns_server).anlist
-    answer.data
+    case query(domain, dns_server).anlist do
+      answers when is_list(answers) and length(answers) > 0 ->
+        data =
+          answers
+          |> Enum.map(&(&1.data))
+          |> Enum.reject(&is_nil/1)
+
+        {:ok, data}
+      _ ->
+        {:error, :not_found}
+    end
   end
 
   @doc """

--- a/test/dns_test.exs
+++ b/test/dns_test.exs
@@ -2,19 +2,36 @@ defmodule DNSTest do
   use ExUnit.Case
   doctest DNS
 
-  test '#resolve' do
-    actual = DNS.resolve('tungdao.com', {'ns1.linode.com', 53})
-    assert {172, 104, 54, 197} = actual
+  describe "resolve" do
+    test "works with default DNS servers" do
+      {:ok, results} = DNS.resolve("www.google.com")
+
+      assert is_list(results)
+      assert length(results) > 0
+    end
+
+    test "works with custom DNS servers" do
+      {:ok, results} = DNS.resolve("www.google.com", {"8.8.4.4", 53})
+
+      assert is_list(results)
+      assert length(results) > 0
+    end
+
+    test "works as expected with not found domain" do
+      assert {:error, :not_found} = DNS.resolve('uifqourefhoqeirhfqeurfhqehfqoerfiuqe.com')
+    end
   end
 
-  test '#query' do
-    assert %DNS.Record{
-      anlist: [],
-      arlist: [],
-      header: %DNS.Header{aa: false, id: 0, opcode: :query, pr: false,
-                          qr: true, ra: true, rcode: 2, rd: false, tc: false},
-      nslist: [],
-      qdlist: [%DNS.Query{class: :in, domain: 'tungdao.com', type: :a}]
-    } = DNS.query('tungdao.com')
+  describe "query" do
+    test "works as expected" do
+      assert %DNS.Record{
+        anlist: [],
+        arlist: [],
+        header: %DNS.Header{aa: false, id: 0, opcode: :query, pr: false,
+                            qr: true, ra: true, rcode: 2, rd: false, tc: false},
+        nslist: [],
+        qdlist: [%DNS.Query{class: :in, domain: 'tungdao.com', type: :a}]
+      } = DNS.query('tungdao.com')
+    end
   end
 end


### PR DESCRIPTION
This PR changes the kind of response that returns `resolve` method. This way we can difference the resolutions with no results.

When results are returned, a tuple like `{:ok, results}` is returned.
When no results are returned, a tuple like `{:error, :not_found}` is returned.

Also, this PR allows to read all responses returned instead of just the first one (and also removing the nils).

The tests has been updated, now testing two more cases with more generic domains and no hardcoded IP addresses.

Typespec and README are both updated too.