### PR TITLE
Adds argument to query different record types

### DIFF
--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -2,12 +2,17 @@ defmodule DNS do
   import Socket.Datagram, only: [send!: 3, recv!: 1]
 
   @doc """
-  TODO: docs
-  TODO: handle errors
+  Resolves the answer for a DNS query
+
+  Example:
+
+      iex> DNS.resolve("tungdao.com")                      # {:ok, [{1, 1, 1, 1}]}
+      iex> DNS.resolve("tungdao.com", :txt)                # {:ok, [['v=spf1 a mx ~all']]}
+      iex> DNS.resolve("tungdao.com", :a, {"8.8.8.8", 53}) # {:ok, [{1, 1, 1, 1}]}
   """
-  @spec resolve(char_list | char_list, { String.t, :inet.port }) :: {atom, :inet.ip} | {atom, atom}
-  def resolve(domain, dns_server \\ { "8.8.8.8", 53 }) do
-    case query(domain, dns_server).anlist do
+  @spec resolve(charlist, atom(), { String.t, :inet.port }) :: {atom, :inet.ip} | {atom, atom}
+  def resolve(domain, type \\ :a, dns_server \\ { "8.8.8.8", 53 }) do
+    case query(domain, type, dns_server).anlist do
       answers when is_list(answers) and length(answers) > 0 ->
         data =
           answers
@@ -21,13 +26,18 @@ defmodule DNS do
   end
 
   @doc """
-  TODO: docs
+  Queries the DNS server and returns the result
+
+  Examples:
+
+      iex> DNS.query("tungdao.com")                              # <= Queries for A records
+      iex> DNS.query("tungdao.com", :mx)                         # <= Queries for the MX records
+      iex> DNS.query("tungdao.com", :a, { "208.67.220.220", 53}) # <= Queries for A records, using OpenDNS
   """
-  @spec query(char_list | char_list, { String.t, :inet.port }) :: DNS.Record.t
-  def query(domain, dns_server \\ { "8.8.8.8", 53 }) do
+  def query(domain, type \\ :a, dns_server \\ { "8.8.8.8", 53 }) do
     record = %DNS.Record{
       header: %DNS.Header{rd: true},
-      qdlist: [%DNS.Query{domain: to_char_list(domain), type: :a, class: :in}]
+      qdlist: [%DNS.Query{domain: to_charlist(domain), type: type, class: :in}]
     }
 
     client = Socket.UDP.open!(0)

--- a/test/dns_test.exs
+++ b/test/dns_test.exs
@@ -1,37 +1,45 @@
 defmodule DNSTest do
   use ExUnit.Case
-  doctest DNS
 
   describe "resolve" do
-    test "works with default DNS servers" do
+    test "defaults DNS servers" do
       {:ok, results} = DNS.resolve("www.google.com")
 
       assert is_list(results)
       assert length(results) > 0
     end
 
-    test "works with custom DNS servers" do
-      {:ok, results} = DNS.resolve("www.google.com", {"8.8.4.4", 53})
+    test "can query custom DNS servers" do
+      {:ok, results} = DNS.resolve("www.google.com", :a, {"8.8.4.4", 53})
 
       assert is_list(results)
       assert length(results) > 0
     end
 
-    test "works as expected with not found domain" do
+    test "responds with error if domain not found" do
       assert {:error, :not_found} = DNS.resolve('uifqourefhoqeirhfqeurfhqehfqoerfiuqe.com')
     end
   end
 
   describe "query" do
-    test "works as expected" do
+    test "builds a DNS Record" do
       assert %DNS.Record{
-        anlist: [],
+        anlist: [%DNS.Resource{}],
         arlist: [],
-        header: %DNS.Header{aa: false, id: 0, opcode: :query, pr: false,
-                            qr: true, ra: true, rcode: 2, rd: false, tc: false},
+        header: %DNS.Header{},
         nslist: [],
-        qdlist: [%DNS.Query{class: :in, domain: 'tungdao.com', type: :a}]
+        qdlist: [%DNS.Query{}]
       } = DNS.query('tungdao.com')
+    end
+
+    test "queries different record types" do
+      assert %DNS.Record{
+        anlist: [%DNS.Resource{}],
+        arlist: [],
+        header: %DNS.Header{},
+        nslist: [],
+        qdlist: [%DNS.Query{}]
+      } = DNS.query('tungdao.com', :txt)
     end
   end
 end


### PR DESCRIPTION
Adds an argument to `query` and `resolve` to query different record types.

**This is a breaking change.** My feeling is that developers will want to query different record types like CNAMES and TXT records more than they will want to query against different DNS servers, so I set the record type to be the 2nd argument.