### PR TITLE
Let Elixir infer application dependencies to fix OTP releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ The package is available in [Hex](https://hex.pm) and can be installed as:
         end
         ```
 
-  3. Ensure dns is started before your application:
-
-        ```elixir
-        def application do
-          [applications: [:dns]]
-        end
-        ```
-
 ## Usage
 
 ### DNS client

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule DNS.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
The `:socket` dependency wasn't being included in OTP releases. This fixes that by letting Elixir infer application deps. This works in Elixir 1.4 and greater.