### PR TITLE
Close the UDP socket after use

### DIFF
--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -46,6 +46,8 @@ defmodule DNS do
     send!(client, DNS.Record.encode(record), dns_server)
 
     {data, _server} = recv!(client)
+
+    :gen_udp.close(client)
     DNS.Record.decode(data)
   end
 end


### PR DESCRIPTION
I am using `DNS.query` in a little dns proxy I am writing.
I noticed several times my nerves device started complaining about too many open files.
After some investigation I traced it back to `DNS.query`. The UDP socket that is used to query the remote DNS-server is never closed.
a simple test was proof:
```elixir
for x <- 1..1000, do: DNS.query("google.com")
** (Socket.Error) too many open files
    (socket) lib/socket/udp.ex:72: Socket.UDP.open!/1
    (dns) lib/dns.ex:44: DNS.query/3
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:232: :erl_eval.expr/5
    (elixir) lib/enum.ex:3003: Enum.reduce_range_inc/4
```
I used `:gen_udp.close/1`, as I did not find a `close` in `Socket` for UDP sockets.