### PR TITLE
Support for RR OPT records and arlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The package is available in [Hex](https://hex.pm) and can be installed as:
 
         ```elixir
         def deps do
-          [{:dns, "~> 2.1.2"}]
+          [{:dns, "~> 2.1.3"}]
         end
         ```
 

--- a/lib/dns/record.ex
+++ b/lib/dns/record.ex
@@ -18,8 +18,9 @@ defmodule DNS.Record do
     header = DNS.Header.to_record(struct.header)
     queries = Enum.map(struct.qdlist, &DNS.Query.to_record/1)
     answers = Enum.map(struct.anlist, &DNS.Resource.to_record/1)
+    additional = Enum.map(struct.arlist, &DNS.Resource.to_record/1)
 
-    _to_record(%{struct | header: header, qdlist: queries, anlist: answers})
+    _to_record(%{struct | header: header, qdlist: queries, anlist: answers, arlist: additional})
   end
 
   defp _to_record(%DNS.Record{unquote_splicing(pairs)}) do
@@ -36,10 +37,16 @@ defmodule DNS.Record do
 
     header = DNS.Header.from_record(struct.header)
     queries = Enum.map(struct.qdlist, &DNS.Query.from_record(&1))
-    answers = Enum.map(struct.anlist, &DNS.Resource.from_record(&1))
-        |> Enum.reject(&is_nil/1)
 
-    %{struct | header: header, qdlist: queries, anlist: answers}
+    answers =
+      Enum.map(struct.anlist, &DNS.Resource.from_record(&1))
+      |> Enum.reject(&is_nil/1)
+
+    additional =
+      Enum.map(struct.arlist, &DNS.Resource.from_record(&1))
+      |> Enum.reject(&is_nil/1)
+
+    %{struct | header: header, qdlist: queries, anlist: answers, arlist: additional}
   end
 
   # TODO: docs

--- a/lib/dns/resource.ex
+++ b/lib/dns/resource.ex
@@ -3,6 +3,8 @@ defmodule DNS.Resource do
   TODO: docs
   """
 
+  require Record
+
   record = Record.extract(:dns_rr, from_lib: "kernel/src/inet_dns.hrl")
   keys = :lists.map(&elem(&1, 0), record)
   vals = :lists.map(&{&1, [], nil}, keys)
@@ -12,20 +14,34 @@ defmodule DNS.Resource do
   @type t :: %__MODULE__{}
 
   @doc """
-  Converts a `DNS.ResourceRecord` struct to a `:dns_rr` record.
+  Converts a `DNS.Resource` or `DNS.ResourceOpt` struct to a `:dns_rr` or `:dns_rr_opt` record.
   """
+  def to_record(resource)
+
   def to_record(%DNS.Resource{unquote_splicing(pairs)}) do
     {:dns_rr, unquote_splicing(vals)}
   end
 
-  @doc """
-  Converts a `:dns_rr` record into a `DNS.ResourceRecord`.
-  """
-  def from_record(dns_rr)
+  def to_record(%DNS.ResourceOpt{} = rr_opt) do
+    DNS.ResourceOpt.to_record(rr_opt)
+  end
 
-  def from_record({:dns_rr, unquote_splicing(vals)}) do
-    %DNS.Resource{unquote_splicing(pairs)}
+  @doc """
+  Converts a `:dns_rr` or `:dns_rr_opt` record into a `DNS.Resource` or `DNS.ResourceOpt`.
+  """
+  def from_record(record)
+
+  def from_record(record) when Record.is_record(record, :dns_rr) do
+    _from_record(record)
+  end
+
+  def from_record(record) when Record.is_record(record, :dns_rr_opt) do
+    DNS.ResourceOpt.from_record(record)
   end
 
   def from_record(_), do: nil
+
+  defp _from_record({:dns_rr, unquote_splicing(vals)}) do
+    %DNS.Resource{unquote_splicing(pairs)}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DNS.Mixfile do
   def project do
     [
       app: :dns,
-      version: "2.1.2",
+      version: "2.1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -41,7 +41,7 @@ defmodule DNS.Mixfile do
       licenses: ["BSD-3-Clauses"],
       links: %{
         "GitHub" => "https://github.com/tungd/elixir-dns",
-        "API Reference" => "http://hexdocs.pm/dns/2.1.2/api-reference.html"
+        "API Reference" => "http://hexdocs.pm/dns/2.1.3/api-reference.html"
       }
     ]
   end


### PR DESCRIPTION
I wanted to be able to return "additional" records (contained in the `arlist` in the `inet_dns` "record" type).

This PR adds a new Elixir module, `DNS.ResourceOpt` (otherwise known as a "pseudo-RR" or "meta-RR" or "RR OPT"). Encoding and decoding resource lists will convert either to the standard `DNS.Resource` or `DNS.ResourceOpt` based on pattern matching.

Also, `DNS.Record._to_record` will now encode the additional records (if any) from the `arlist` when sending data in the response.