### PR TITLE
Fix master

### DIFF
--- a/lib/dns/resource.ex
+++ b/lib/dns/resource.ex
@@ -45,3 +45,8 @@ defmodule DNS.Resource do
     %DNS.Resource{unquote_splicing(pairs)}
   end
 end
+
+# psudo-RR type OPT - https://en.wikipedia.org/wiki/Extension_mechanisms_for_DNS#mechanism
+defmodule DNS.ResourceOpt do 
+  defstruct Record.extract(:dns_rr_opt, from_lib: "kernel/src/inet_dns.hrl")
+end

--- a/lib/dns/resource.ex
+++ b/lib/dns/resource.ex
@@ -1,3 +1,8 @@
+# psudo-RR type OPT - https://en.wikipedia.org/wiki/Extension_mechanisms_for_DNS#mechanism
+defmodule DNS.ResourceOpt do 
+  defstruct Record.extract(:dns_rr_opt, from_lib: "kernel/src/inet_dns.hrl")
+end
+
 defmodule DNS.Resource do
   @moduledoc """
   TODO: docs
@@ -44,9 +49,4 @@ defmodule DNS.Resource do
   defp _from_record({:dns_rr, unquote_splicing(vals)}) do
     %DNS.Resource{unquote_splicing(pairs)}
   end
-end
-
-# psudo-RR type OPT - https://en.wikipedia.org/wiki/Extension_mechanisms_for_DNS#mechanism
-defmodule DNS.ResourceOpt do 
-  defstruct Record.extract(:dns_rr_opt, from_lib: "kernel/src/inet_dns.hrl")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DNS.Mixfile do
   def project do
     [
       app: :dns,
-      version: "2.1.3",
+      version: "2.1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.9.1", "f021affa11b32a94dc2e807a6472ce0914289c9132f99644a97fc84432b202a1", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "0.9.1", "f021affa11b32a94dc2e807a6472ce0914289c9132f99644a97fc84432b202a1", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "d869ef519c3eea180296c7fb6fd48bb797d4ee82c82a7bfa321a3441ac38c5e5"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "eacdfd22d5c7e5f3fda086214c69a8b6ca4298ad90d99f399d591f14eead6a61"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
 }


### PR DESCRIPTION
Hi there, 

It seems that the master branch is broken, and was broken with #32. I went to implement a feature PR #24 but couldn't get things running without fixing this first!

Specifically I'm seeing this:
```
$ mix test
Compiling 6 files (.ex)

== Compilation error in file lib/dns/resource.ex ==
** (CompileError) lib/dns/resource.ex:25: DNS.ResourceOpt.__struct__/0 is undefined, cannot expand struct DNS.ResourceOpt. Make sure the struct name is correct. If the struct name exists and is correct but it still cannot be found, you likely have cyclic module usage in your code
    lib/dns/resource.ex:25: (module)
```

Which is also what has master failing on Travis https://travis-ci.org/github/tungd/elixir-dns/jobs/724809205#L229. 

It looks like the PR that introduced this break doesn't actually include a `DNS.ResourceOpt` module, so I added one, and moved it into its own struct at the bottom of `resource.ex`. I *believe* that's what @pzingg was going for and things should now be happy but I'm not 100% sure - @pzingg can you help confirm?