### PR TITLE
replace custom dns implementation with :inet_res.resolve

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :dns, :server,
-  port: 8053
+config :dns, :server, port: 8053

--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -1,4 +1,15 @@
 defmodule DNS do
+
+  @type nameserver :: {String.t(), port :: 1..65535}
+  @type res_option ::
+  :inet_res.res_option()
+  | {:alt_nameservers, [nameserver()]}
+  | {:nameservers, [nameserver()]}
+  # :inet_res.rr_type is not exported
+  @type rr_type :: :a | :aaaa | :caa | :cname | :gid | :hinfo | :ns | :mb | :md | :mg
+  | :mf | :minfo | :mx | :naptr | :null | :ptr | :soa | :spf | :srv
+  | :txt | :uid | :uinfo | :unspec | :uri | :wks
+
   @doc """
   Resolves the answer for a DNS query.
 
@@ -10,27 +21,29 @@ defmodule DNS do
       iex> DNS.resolve("tungdao.com", :txt)
       {:ok, [['v=spf1 a mx ~all']]}
 
-      iex> DNS.resolve("tungdao.com", :a, {"8.8.8.8", 53})
+      iex> DNS.resolve("tungdao.com", :a, nameservers: [{"8.8.4.4", 53}])
       {:ok, [{1, 1, 1, 1}]}
 
-      iex> DNS.resolve("tungdao.com", :a, {"8.8.8.8", 53}, :tcp)
+      iex> DNS.resolve("tungdao.com", :a, usevc: true)
       {:ok, [{1, 1, 1, 1}]}
 
   """
-  @spec resolve(String.t(), atom, {String.t(), :inet.port()}, :tcp | :udp) ::
-          {atom, :inet.ip()} | {atom, list} | {atom, atom}
-  def resolve(domain, type \\ :a, dns_server \\ {"8.8.8.8", 53}, proto \\ :udp) do
-    case query(domain, type, dns_server, proto).anlist do
-      answers when is_list(answers) and length(answers) > 0 ->
+  @spec resolve(String.t(), rr_type(), [res_option()], timeout()) :: {:ok, list()} | {:error, :inet_res.res_error()}
+  def resolve(domain, type \\ :a, opts \\ [], timeout \\ :infinity) do
+    case query(domain, type, opts, timeout) do
+      {:ok, %DNS.Record{anlist: anlist}} when is_list(anlist) and length(anlist) > 0 ->
         data =
-          answers
+          anlist
           |> Enum.map(& &1.data)
           |> Enum.reject(&is_nil/1)
 
         {:ok, data}
 
-      _ ->
+      {:ok, %DNS.Record{anlist: anlist}} when is_list(anlist) and length(anlist) == 0 ->
         {:error, :not_found}
+
+      error ->
+        error
     end
   end
 
@@ -49,50 +62,41 @@ defmodule DNS do
 
   Queries for A records, using OpenDNS:
 
-      iex> DNS.query("tungdao.com", :a, { "208.67.220.220", 53})
+      iex> DNS.query("tungdao.com", :a, nameservers: [{"8.8.4.4", 53}])
 
 
   Queries for A records, using OpenDNS, with TCP:
 
-      iex> DNS.query("tungdao.com", :a, { "208.67.220.220", 53}, :tcp)
+      iex> DNS.query("tungdao.com", :a, nameservers: [{"8.8.4.4", 53}], usevc: true)
 
   """
-  @spec query(String.t(), atom, {String.t(), :inet.port()}, :tcp | :udp) :: DNS.Record.t()
-  def query(domain, type \\ :a, dns_server \\ {"8.8.8.8", 53}, proto \\ :udp) do
-    record = %DNS.Record{
-      header: %DNS.Header{rd: true},
-      qdlist: [%DNS.Query{domain: to_charlist(domain), type: type, class: :in}]
-    }
+  @spec query(String.t(), rr_type(), [res_option()], timeout()) :: {:ok, DNS.Record.t()} | {:error, :inet_res.res_error()}
+  def query(name, type \\ :a, opts \\ [], timeout \\ :infinity) do
+    case :inet_res.resolve(to_charlist(name), :in, type, transform_opts(opts), timeout) do
+      {:ok, response} ->
+        {:ok, DNS.Record.from_record(response)}
 
-    encoded_record = DNS.Record.encode(record)
+      {:error, error} ->
+        {:error, error}
+    end
+  end
 
-    response_data =
-      case proto do
-        :udp ->
-          client = Socket.UDP.open!(0)
+  defp transform_opts(opts) do
+    Enum.map(opts, fn {key, value} -> {key, transform_opt(key, value)} end)
+  end
 
-          Socket.Datagram.send!(client, encoded_record, dns_server)
-
-          {data, _server} = Socket.Datagram.recv!(client, timeout: 5_000)
-
-          :gen_udp.close(client)
-
-          data
-
-        :tcp ->
-          # Set our packet mode to be 2, which indicates there is a 2 byte, big
-          # endian length field on our packets sent and recv'd
-          socket = Socket.TCP.connect!(dns_server, timeout: 5_000, packet: 2)
-
-          :ok = Socket.Stream.send(socket, encoded_record)
-
-          data = Socket.Stream.recv!(socket)
-
-          Socket.Stream.close!(socket)
-
-          data
+  defp transform_opt(key, nameservers) when key in [:alt_nameservers, :nameservers] and is_list(nameservers) do
+    Enum.map(nameservers, fn {nameserver, port} ->
+      case nameserver do
+        n when is_tuple(n) -> {n, port}
+        n when is_binary(n) ->
+          {:ok, address} = :inet.parse_address(to_charlist(n))
+          {address, port}
       end
+    end)
+  end
 
-    DNS.Record.decode(response_data)
+  defp transform_opt(_key, value) do
+    value
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,6 @@ defmodule DNS.Mixfile do
 
   defp deps do
     [
-      {:socket, "~> 0.3.13"},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:credo, "~> 0.9.0-rc1", only: [:dev, :test], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "credo": {:hex, :credo, "0.9.1", "f021affa11b32a94dc2e807a6472ce0914289c9132f99644a97fc84432b202a1", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "d869ef519c3eea180296c7fb6fd48bb797d4ee82c82a7bfa321a3441ac38c5e5"},
-  "earmark": {:hex, :earmark, "1.4.10", "bddce5e8ea37712a5bfb01541be8ba57d3b171d3fa4f80a0be9bcf1db417bcaf", [:mix], [{:earmark_parser, ">= 1.4.10", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "12dbfa80810478e521d3ffb941ad9fbfcbbd7debe94e1341b4c4a1b2411c1c27"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
   "ex_doc": {:hex, :ex_doc, "0.24.2", "e4c26603830c1a2286dae45f4412a4d1980e1e89dc779fcd0181ed1d5a05c8d9", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "e134e1d9e821b8d9e4244687fb2ace58d479b67b282de5158333b0d57c6fb7da"},
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
@@ -9,5 +8,4 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
 }

--- a/test/dns_test.exs
+++ b/test/dns_test.exs
@@ -10,18 +10,18 @@ defmodule DNSTest do
     end
 
     test "can query custom DNS servers" do
-      {:ok, results} = DNS.resolve("www.google.com", :a, {"8.8.4.4", 53})
+      {:ok, results} = DNS.resolve("www.google.com", :a, nameservers: [{"8.8.4.4", 53}])
 
       assert is_list(results)
       assert length(results) > 0
     end
 
     test "responds with error if domain not found" do
-      assert {:error, :not_found} = DNS.resolve('uifqourefhoqeirhfqeurfhqehfqoerfiuqe.com')
+      assert {:error, :nxdomain} = DNS.resolve('uifqourefhoqeirhfqeurfhqehfqoerfiuqe.com')
     end
 
     test "can query DNS servers via tcp" do
-      {:ok, results} = DNS.resolve("www.google.com", :a, {"8.8.4.4", 53}, :tcp)
+      {:ok, results} = DNS.resolve("www.google.com", :a, usevc: true)
 
       assert is_list(results)
       assert length(results) > 0


### PR DESCRIPTION
OTP built in DNS resolution already does a lot of work implementing
more options. This library should just wrap OTP primarily so we can
use structs instead of records in Elixir.
PS. This makes some breaking changes to the API