### PR TITLE
Update DNS.resolve example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ iex> DNS.query("google.com")
   ra: true, rcode: 0, rd: false, tc: false}, nslist: [],
  qdlist: [%DNS.Query{class: :in, domain: 'google.com', type: :a}]}
 
-iex> DNS.resolve("google.com", :a, {"8.8.8.8", 53})
+iex> DNS.resolve("google.com", :a, nameservers: [{"8.8.8.8", 53}])
 ...
 ```
 


### PR DESCRIPTION
Thanks for writing this library! I was just exploring it for a project and noticed that the resolve example in the README failed on my machine w/ `protocol Enumerable not implemented for {"8.8.8.8", 53} of type Tuple.` (Elixir 1.14.2 + OTP 25.1.2)

Updated the readme to a working example.
